### PR TITLE
Milestones 1 and 2

### DIFF
--- a/ADC_Stream.cc
+++ b/ADC_Stream.cc
@@ -1,0 +1,215 @@
+// -!- C++ -!- //////////////////////////////////////////////////////////////
+//
+//  System        : 
+//  Module        : 
+//  Object Name   : $RCSfile$
+//  Revision      : $Revision$
+//  Date          : $Date$
+//  Author        : $Author$
+//  Created By    : Robert Heller
+//  Created       : Sat Sep 5 15:17:04 2020
+//  Last Modified : <200905.1714>
+//
+//  Description	
+//
+//  Notes
+//
+//  History
+//	
+/////////////////////////////////////////////////////////////////////////////
+//
+//    Copyright (C) 2020  Robert Heller D/B/A Deepwoods Software
+//			51 Locke Hill Road
+//			Wendell, MA 01379-9728
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+// 
+//
+//////////////////////////////////////////////////////////////////////////////
+
+static const char rcsid[] = "@(#) : $Id$";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <signal.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#include <prussdrv.h>
+#include <pruss_intc_mapping.h>
+
+#include "spidriver_host.h"
+#include "adcdriver_host.h"
+
+#include "ADC_Stream.h"
+
+#define SPI_PRU	0
+#define CLK_PRU 1
+
+// Commands to AD7172
+#define READ_ID_REG 0x47
+#define READ_DATA_REG 0x44
+#define READ_STATUS_REG 0x40
+#define WRITE_CH0_REG 0x10
+#define WRITE_CH1_REG 0x11
+#define WRITE_SETUPCON0_REG 0x20
+#define WRITE_ADCMODE_REG 0x01
+#define WRITE_IFMODE_REG 0x02
+#define WRITE_GPIOCON_REG 0x06
+#define WRITE_FILTERCON0_REG 0x28
+
+/** Start function implementation.
+ */
+void ADC_Stream::Start(Callback_t callback, void *usercontext)
+{
+    // Initialize instance variables:
+    callback_ = callback;          // Save Callback function
+    usercontext_ = usercontext;    // Save User Context
+    end_ = false;                  // Not the end
+    newdata_ = false;              // New Data flag (no new data yet).
+    
+    inpointer_ = 0;                // Reset Ring Buffer pointer indexes
+    outpointer_ = 0;
+    // Create thread to read data
+    int result = pthread_create(&threadHandle_,NULL,
+                                ADC_Stream::thread__,
+                                (void *)this);
+    // Error check
+    if (result != 0)
+    {
+        perror("ADC_Stream::Start:");
+        exit(result);
+    }
+    // Loop until end.
+    while (!end_) {
+        usleep(100000);             // sleep 100 ms.
+        if (newdata_) {             // new data check
+            newdata_ = false;       // reset flag
+            // Compute how much data is available
+            uint32_t dataavailable = inpointer_ - outpointer_;
+            // Wrap around
+            if (dataavailable < 0) {
+                dataavailable = RINGBUFFERSIZE - dataavailable;
+            }
+            // Call Callback function
+            (*callback_)(this,dataavailable,usercontext_);
+        }
+    }
+}
+
+/** Stop function implementation */
+void ADC_Stream::Stop(void)
+{
+    void *result = NULL; // holds result (not used)
+    end_ = true;         // Set end flag
+    
+    pthread_join(threadHandle_,&result); // Wait for thread to stop
+}
+
+/** Get data function implementation */
+uint32_t ADC_Stream::GetData(uint32_t offset, uint32_t count, 
+                             float *buffer, bool update)
+{
+    int i;
+    // Compute data available
+    uint32_t dataavailable = inpointer_ - outpointer_;
+    // Wraparound
+    if (dataavailable < 0) {
+        dataavailable = RINGBUFFERSIZE - dataavailable;
+    }
+    // Adjust count, if data available is less than count.
+    if (dataavailable < count+offset) count = dataavailable-offset;
+    // Compute start index
+    uint32_t start = (outpointer_+offset)%RINGBUFFERSIZE;
+    // Check for wraparound
+    if (start + count < RINGBUFFERSIZE) {
+        // No wraparound, convert to float into user buffer
+        for (i = 0; i < count; i++) {
+            buffer[i] = adc_GetVoltage(RingBuffer_[start+i]);
+        }
+    } else {
+        // Wraparound case
+        // Before 12 o'clock part
+        uint32_t count1 = RINGBUFFERSIZE - start;
+        for (i = 0; i < count1; i++) {
+            buffer[i] = adc_GetVoltage(RingBuffer_[start+i]);
+        }
+        // After 12 o'clock part 
+        buffer+=count1;
+        uint32_t remainder = count-count1;
+        for (i = 0; i < remainder; i++) {
+            buffer[i] = adc_GetVoltage(RingBuffer_[i]);
+        }
+    }
+    if (update) {    // Check if updating pointer
+        pthread_mutex_lock(&highmutex_);
+        outpointer_ = (outpointer_+offset+count)%RINGBUFFERSIZE;
+        pthread_mutex_unlock(&highmutex_);
+    }
+    return count;
+}
+
+/** Data aquistation thread implementation */
+void * ADC_Stream::thread_()
+{
+    // Loop until end
+    while (!end_) {
+        // command buffer
+        uint32_t tx_buf[3];
+        int i, j;
+        
+        // Set up ADC mode reg for continuous conversation
+        
+        // Write mode register
+        //printf("WRITE_ADCMODE_REG\n");
+        tx_buf[0] = WRITE_ADCMODE_REG;
+        tx_buf[1] = 0x00;
+        tx_buf[2] = 0x0c;
+        spi_write_cmd(tx_buf, 3);
+        
+        // Read samples from data register to buffer
+        tx_buf[0] = READ_DATA_REG;
+        spi_writeread_continuous(tx_buf, 1, SPIBuffer_, 3, 
+                                 SPIBUFFERSIZE);
+        
+        pthread_mutex_lock(&highmutex_); // Lock
+        // Check for wraparound.
+        if (inpointer_+SPIBUFFERSIZE <= RINGBUFFERSIZE) {
+            // No wraparound, one step copy
+            memcpy(&RingBuffer_[inpointer_],SPIBuffer_,
+                   SPIBUFFERSIZE*sizeof(uint32_t));
+        } else {
+            // Wraparound case.  Split the copy into two parts:
+            // before 12 o'clock and after 12 o'clock.
+            uint32_t count = RINGBUFFERSIZE - inpointer_;
+            memcpy(&RingBuffer_[inpointer_],SPIBuffer_,
+                   count*sizeof(uint32_t));
+            uint32_t remainder = SPIBUFFERSIZE-count;
+            memcpy(RingBuffer_,SPIBuffer_+count,
+                   remainder*sizeof(uint32_t));
+        }
+        // Update point index
+        inpointer_ = (inpointer_+SPIBUFFERSIZE) % RINGBUFFERSIZE;
+        pthread_mutex_unlock(&highmutex_); // unlock
+        // Flag newdata
+        newdata_ = true;
+    }
+}
+
+            

--- a/ADC_Stream.cc
+++ b/ADC_Stream.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 15:17:04 2020
-//  Last Modified : <200911.1513>
+//  Last Modified : <200914.1235>
 //
 //  Description	
 //
@@ -177,7 +177,7 @@ void * ADC_Stream::thread_()
     // Set up ADC mode reg for continuous conversation
     
     // Write mode register
-    printf("WRITE_ADCMODE_REG\n");
+    //printf("WRITE_ADCMODE_REG\n");
     tx_buf[0] = WRITE_ADCMODE_REG;
     tx_buf[1] = 0x00;
     tx_buf[2] = 0x0c;
@@ -188,18 +188,18 @@ void * ADC_Stream::thread_()
     // Initialize by filling the buffer at offset 0.
     prev_rxptr = spi_writeread_continuous_start(tx_buf, 1, 0, 3, 
                                                 SPIBUFFERSIZE);
-    fprintf(stderr,"*** ADC_Stream::thread_(): after spi_writeread_continuous_start - prev_rxptr is %d\n",prev_rxptr);
+    //fprintf(stderr,"*** ADC_Stream::thread_(): after spi_writeread_continuous_start - prev_rxptr is %d\n",prev_rxptr);
     // Then we will fill the buffer at SPIBUFFERSIZE offset
     current_offset = SPIBUFFERSIZE;
     // Loop until end
     while (!end_) {
-        fprintf(stderr,"*** ADC_Stream::thread_(): top of while loop: current_offset = %d\n",current_offset);
+        //fprintf(stderr,"*** ADC_Stream::thread_(): top of while loop: current_offset = %d\n",current_offset);
         // Wait for the previous buffer to fill, then start filling
         // the other buffer.
         spi_writeread_continuous_wait();
         
         // Write mode register
-        printf("WRITE_ADCMODE_REG\n");
+        //printf("WRITE_ADCMODE_REG\n");
         tx_buf[0] = WRITE_ADCMODE_REG;
         tx_buf[1] = 0x00;
         tx_buf[2] = 0x0c;
@@ -211,7 +211,7 @@ void * ADC_Stream::thread_()
                                                         current_offset,
                                                         3, 
                                                         SPIBUFFERSIZE);
-        fprintf(stderr,"*** ADC_Stream::thread_(): after spi_writeread_continuous_wait - prev_rxptr = %d\n",prev_rxptr);
+        //fprintf(stderr,"*** ADC_Stream::thread_(): after spi_writeread_continuous_wait - prev_rxptr = %d\n",prev_rxptr);
         // Copy the previous buffer to the ring.
         spi_writeread_continuous_transfer(prev_rxptr, SPIBUFFERSIZE,
                                           &RingBuffer_[inpointer_]);

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ CXX := g++
 CFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
 CXXFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
 # LDFLAGS := -lprussdrv
+LDFLAGS := -lrt -lpthread
 
 SRCS := main.c prussdrv.c adcdriver_host.c spidriver_host.c ADC_Stream.cc
 OBJS := main.o prussdrv.o adcdriver_host.o spidriver_host.o
-#OBJS1 = mainstream1.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
+OBJS1 = mainstream1.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
 #OBJS2 = mainstream2.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
-EXES := main # mainstream1 mainstream2
+EXES := main mainstream1 # mainstream2
 INCLUDEDIR := ./include
 INCLUDES := $(addprefix $(INCLUDEDIR)/, prussdrv.h pru_types.h __prussdrv.h pruss_intc_mapping.h spidriver_host.h adcdriver_host.h)
 
@@ -43,16 +44,23 @@ PRU1_EXES := data1.bin text1.bin
 PRU_HEXPRU_SCRIPT := bin.cmd
 
 #=================================================
-all: main pru0.bin pru1.bin ADC_001-00A0.dtbo
+all: $(EXES) pru0.bin pru1.bin ADC_001-00A0.dtbo
 
-bins: main pru0.bin
+bins: $(EXES) pru0.bin
 
 #--------------------------------
 # Compile ARM sources for host.
-main.o: $(SRCS)
+main.o: main.c include/spidriver_host.h include/adcdriver_host.h
 	echo "--> Building main.o"
 	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
+
+mainstream1.o: mainstream1.cc include/ADC_Stream.h \
+	include/spidriver_host.h include/adcdriver_host.h
+	echo "--> Building mainstream1.o"
+	$(CXX) $(CXXFLAGS) -E -MM  -c $< -MF $<.d
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+	
 
 adcdriver_host.o: adcdriver_host.c ./include/adcdriver_host.h
 	echo "--> Building adcdriver_host.o"
@@ -76,10 +84,14 @@ ADC_Stream.o: ADC_Stream.cc # $(DEPS)
 
 # Link the ARM objects
 main: $(OBJS) 
-	echo "--> Linking ARM stuff...."
+	echo "--> Linking main ...."
 	$(CC) $(CFLAGS) $^ $(LIBLOCS) $(LDFLAGS) -o $@ 
 
 $(OBJS): $(INCLUDES)
+
+mainstream1: $(OBJS1)
+	echo "--> Linking mainstream1 ...."
+	$(CXX) $(CXXFLAGS) $^ $(LIBLOCS) $(LDFLAGS) -o $@
 
 #--------------------------------
 # Compile and link the PRU sources to create ELF executable

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,16 @@
 #----------------------------------------------------
 # ARM code
 CC := gcc
-CFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include 
+CXX := g++
+CFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
+CXXFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
 # LDFLAGS := -lprussdrv
 
-SRCS := main.c prussdrv.c adcdriver_host.c spidriver_host.c
+SRCS := main.c prussdrv.c adcdriver_host.c spidriver_host.c ADC_Stream.cc
 OBJS := main.o prussdrv.o adcdriver_host.o spidriver_host.o
-EXES := main
+#OBJS1 = mainstream1.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
+#OBJS2 = mainstream2.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
+EXES := main # mainstream1 mainstream2
 INCLUDEDIR := ./include
 INCLUDES := $(addprefix $(INCLUDEDIR)/, prussdrv.h pru_types.h __prussdrv.h pruss_intc_mapping.h spidriver_host.h adcdriver_host.h)
 
@@ -47,19 +51,28 @@ bins: main pru0.bin
 # Compile ARM sources for host.
 main.o: $(SRCS)
 	echo "--> Building main.o"
+	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
 adcdriver_host.o: adcdriver_host.c ./include/adcdriver_host.h
 	echo "--> Building adcdriver_host.o"
+	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
 spidriver_host.o: spidriver_host.c ./include/spidriver_host.h
 	echo "--> Building spidriver_host.o"
+	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
 prussdrv.o: prussdrv.c # $(DEPS)
 	echo "--> Building prussdrv.o"
+	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
+
+ADC_Stream.o: ADC_Stream.cc # $(DEPS)
+	echo "--> Building ADC_Stream.o"
+	$(CXX) $(CXXFLAGS) -E -MM  -c $< -MF $<.d
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # Link the ARM objects
 main: $(OBJS) 

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -1,0 +1,176 @@
+// -!- c++ -!- //////////////////////////////////////////////////////////////
+//
+//  System        : 
+//  Module        : 
+//  Object Name   : $RCSfile$
+//  Revision      : $Revision$
+//  Date          : $Date$
+//  Author        : $Author$
+//  Created By    : Robert Heller
+//  Created       : Sat Sep 5 14:26:26 2020
+//  Last Modified : <200905.1711>
+//
+//  Description	
+//
+//  Notes
+//
+//  History
+//	
+/////////////////////////////////////////////////////////////////////////////
+//
+//    Copyright (C) 2020  Robert Heller D/B/A Deepwoods Software
+//			51 Locke Hill Road
+//			Wendell, MA 01379-9728
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+// 
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef __ADC_STREAM_H
+#define __ADC_STREAM_H
+
+#include <stdint.h>
+#include <pthread.h>
+
+/** Buffer sizes.  These are the sizes of the buffers
+ */
+
+#define SPIBUFFERSIZE 1024 // Low-level SPI buffer
+#define RINGBUFFERSIZE 8192 // High-level ring buffer
+
+
+/** ADC_Stream, a class to encapsulate streaming data from the ADC 
+ * Cape.  This class implements continious streaming from the ADC,
+ * using a ring buffer.  The low-level PRU SPI transfers are handled 
+ * with a separate thread, while the main thread processes the data
+ * that is available in the ring buffer.
+ * 
+ */
+
+class ADC_Stream {
+public:
+    /** Callback function type.  This is the type of the user-supplied
+     * call back function.  This function is called as new data 
+     * becomes available.  It is passed the class instance's this
+     * pointer, the number of 32-bit floating point values currently
+     * available, and a user supplied context pointer.
+     */
+    typedef void (*Callback_t)(ADC_Stream *stream,uint32_t available,
+                               void *usercontext);
+    /** Constructor: initialize instance variables.
+     */
+    ADC_Stream()
+                : highmutex_(PTHREAD_MUTEX_INITIALIZER)
+          , inpointer_(0)
+          , outpointer_(0)
+          , end_(true)
+    {
+    }
+    /** Start function.  This function starts the data collection
+     * thread.
+     * The data collection thread is started.  Once a batch of data 
+     * becomes available, the callback function is called.  The
+     * callback function is called whenever an additional batch of
+     * data becomes available.  
+     * Parameters:
+     *     callback is the callback function.
+     *     usercontext is a user supplied pointer that gets
+     *                 passed to the callback function.
+     * Returns void
+     */
+    void Start(Callback_t callback, void *usercontext = NULL);
+    /** End function.  This function stops the data collection thread.
+     * The data collection thread is stopped and data streaming
+     * ceases.
+     * Parameters:
+     *      None.
+     * Returns void
+     */
+    void Stop(void);
+    /** GetData function.  This function fetches a block of data from
+     * the ring buffer and optionally advances the outpointer.
+     * Parameters:
+     *     offset is the offset from the outpointer to start copying
+     *            data from
+     *     count is the maximum number of 32-bit floats to copy.
+     *           If fewer 32-bit floats are available, then only
+     *           number of available 32-bit floats are copied.
+     *     buffer is where to copy the data to.
+     *     update is a flag to indicate if the outpointer should be
+     *            advanced.  If true, the outpointer is advanced by
+     *            offset+count 32-bit floats, that is to just after
+     *            the block fetched.
+     * Returns the actual number of 32-bit floats copied.
+     */
+    uint32_t GetData(uint32_t offset, uint32_t count, float *buffer, 
+                     bool update=false);
+private:
+    /** Static thread function.
+     * This static function just calls the member function that 
+     * implements the thread.
+     * Parameters:
+     *     param is the this pointer
+     * Returns the result of the thread
+     */
+    static void *thread__(void *param)
+    {
+        ADC_Stream *thispointer = (ADC_Stream *) param;
+        return thispointer->thread_();
+    }
+    /** Low level buffering thread.  This is the implementation of the
+     * low-level buffering thread.
+     * Parameters:
+     *     None
+     * Returns the result of the thread.
+     */
+    void *thread_();
+    /** User callback function.  This is the user callback function.
+      */    
+    Callback_t callback_;
+    /** User context pointer.  This us the user callback context 
+     * pointer
+     */
+    void *     usercontext_;
+    /** The ring buffer.  This is the large circular (ring) buffer
+     * containing the raw samples from the ADC.
+     */
+    uint32_t RingBuffer_[RINGBUFFERSIZE];
+    /** Input pointer (index) of the ring buffer.  New data is added
+     * at this index.
+     */
+    int inpointer_;
+    /** Output pointer (index) of the ring buffer.  Application data
+     * is returned starting from this index.
+     */
+    int outpointer_;
+    /** The SPI buffer.  This is the smaller buffer of raw (uint32s)
+     * samples from the ADC copied directly from the PRU's data RAM.
+     */
+    uint32_t SPIBuffer_[SPIBUFFERSIZE];
+    /** Mutex for the high-level Ring buffer. */
+    pthread_mutex_t highmutex_;
+    /** End flag. When true, streaming is stopped. */
+    bool end_;
+    /** Thread object. */
+    pthread_t threadHandle_;
+    /** New data flag */
+    bool newdata_;
+};
+    
+
+#endif // __ADC_STREAM_H
+

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 14:26:26 2020
-//  Last Modified : <200905.1711>
+//  Last Modified : <200906.1004>
 //
 //  Description	
 //
@@ -50,7 +50,7 @@
  */
 
 #define SPIBUFFERSIZE 1024 // Low-level SPI buffer
-#define RINGBUFFERSIZE 8192 // High-level ring buffer
+#define RINGBUFFERSIZE (8*SPIBUFFERSIZE) // High-level ring buffer
 
 
 /** ADC_Stream, a class to encapsulate streaming data from the ADC 
@@ -157,10 +157,6 @@ private:
      * is returned starting from this index.
      */
     int outpointer_;
-    /** The SPI buffer.  This is the smaller buffer of raw (uint32s)
-     * samples from the ADC copied directly from the PRU's data RAM.
-     */
-    uint32_t SPIBuffer_[SPIBUFFERSIZE];
     /** Mutex for the high-level Ring buffer. */
     pthread_mutex_t highmutex_;
     /** End flag. When true, streaming is stopped. */

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 14:26:26 2020
-//  Last Modified : <200906.1004>
+//  Last Modified : <200914.1222>
 //
 //  Description	
 //
@@ -49,7 +49,7 @@
 /** Buffer sizes.  These are the sizes of the buffers
  */
 
-#define SPIBUFFERSIZE 1024 // Low-level SPI buffer
+#define SPIBUFFERSIZE 512 // Low-level SPI buffer
 #define RINGBUFFERSIZE (8*SPIBUFFERSIZE) // High-level ring buffer
 
 

--- a/include/adcdriver_host.h
+++ b/include/adcdriver_host.h
@@ -1,6 +1,10 @@
 #ifndef ADCDRIVER_HOST_H
 #define ADCDRIVER_HOST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Allowed sample rates.  These are set by the AD7172 hardware.
 // Consult the AD7172 datasheet for more info.  
 #define SAMP_RATE_31250 5
@@ -37,6 +41,10 @@ void adc_read_multiple(uint32_t read_cnt, float *volts);
 // Low level fcns
 void adc_write(uint32_t *tx_buf, int byte_cnt);
 void adc_writeread(uint32_t *tx_buf, int tx_cnt, uint32_t *rx_buf, int rx_cnt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/include/spidriver_host.h
+++ b/include/spidriver_host.h
@@ -1,6 +1,10 @@
 #ifndef SPIDRIVER_HOST_H
 #define SPIDRIVER_HOST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Global pointer to base of PRU0 RAM.  This is the place
 // where commands and data are communicated between the host
 // ARM processor and the PRU.  The memory buffer is defined in
@@ -23,6 +27,7 @@ void spi_reset_cmd(void);
 
 // Low level fcns for internal use.
 uint32_t pru_read_word(uint32_t offset);
+void pru_read_block(uint32_t offset, uint32_t count, uint32_t *buffer);
 void pru_write_word(uint32_t offset, uint32_t value);
 
 // Debug and diagnostic stuff.
@@ -33,6 +38,10 @@ uint32_t pru_test_communication(void);
 uint32_t spi_write_cmd(uint32_t *data, int byte_cnt);
 uint8_t spi_writeread_single(uint32_t *txdata, int txcnt, uint32_t *rxdata, int rxcnt);
 uint8_t spi_writeread_continuous(uint32_t *txdata, int txcnt, uint32_t *rxdata, int rxcnt, int ncnv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/include/spidriver_host.h
+++ b/include/spidriver_host.h
@@ -39,6 +39,11 @@ uint32_t spi_write_cmd(uint32_t *data, int byte_cnt);
 uint8_t spi_writeread_single(uint32_t *txdata, int txcnt, uint32_t *rxdata, int rxcnt);
 uint8_t spi_writeread_continuous(uint32_t *txdata, int txcnt, uint32_t *rxdata, int rxcnt, int ncnv);
 
+uint32_t  spi_writeread_continuous_start(uint32_t *txdata, int txcnt, uint32_t rxoffset, int rxcnt, int ncnv);
+uint32_t spi_writeread_continuous_waitstart(uint32_t *txdata, int txcnt, uint32_t rxoffset, int rxcnt, int ncnv);
+void spi_writeread_continuous_wait();
+uint8_t spi_writeread_continuous_transfer(uint32_t rxptr,int ncnv, uint32_t *rxdata);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mainstream1.cc
+++ b/mainstream1.cc
@@ -1,0 +1,162 @@
+// -!- C++ -!- //////////////////////////////////////////////////////////////
+//
+//  System        : 
+//  Module        : 
+//  Object Name   : $RCSfile$
+//  Revision      : $Revision$
+//  Date          : $Date$
+//  Author        : $Author$
+//  Created By    : Robert Heller
+//  Created       : Fri Sep 11 13:08:51 2020
+//  Last Modified : <200911.1429>
+//
+//  Description	
+//
+//  Notes
+//
+//  History
+//	
+/////////////////////////////////////////////////////////////////////////////
+//
+//    Copyright (C) 2020  Robert Heller D/B/A Deepwoods Software
+//			51 Locke Hill Road
+//			Wendell, MA 01379-9728
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//
+// 
+//
+//////////////////////////////////////////////////////////////////////////////
+
+static const char rcsid[] = "@(#) : $Id$";
+
+#include <stdio.h>
+#include <stdlib.h>
+// #include <stdarg.h>
+#include <stdint.h>
+#include <signal.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "spidriver_host.h"
+#include "adcdriver_host.h"
+
+#include "ADC_Stream.h"
+
+class TimedStream {
+public:
+    TimedStream()
+    {
+    }
+    void start(ADC_Stream *stream,int seconds,FILE *ofp) {
+
+        struct sigevent sev;         // Timer event
+        struct itimerspec its;       // Timer interval structs.
+
+        sev.sigev_notify = SIGEV_NONE;
+        if (timer_create(CLOCK_REALTIME, &sev, &timerid_) == -1) {
+            perror("timer_create");
+            exit(EXIT_FAILURE);
+        }
+        its.it_value.tv_sec = seconds;
+        its.it_value.tv_nsec = 0;
+        its.it_interval.tv_sec = 0;
+        its.it_interval.tv_nsec = 0;
+        
+        if (timer_settime(timerid_, 0, &its, NULL) == -1) {
+            perror("timer_settime");
+            exit(EXIT_FAILURE);
+        }
+
+        ofp_ = ofp;
+        stream->Start(TimedStream::callback__,(void *)this);
+    }
+private:
+    static void callback__(ADC_Stream *stream,uint32_t available,
+                           void *usercontext)
+    {
+        TimedStream *thispointer = (TimedStream *) usercontext;
+        thispointer->callback_(stream,available);
+    }
+    void callback_(ADC_Stream *stream,uint32_t available)
+    {
+        float buffer[1024];
+        uint32_t count, index;
+        struct itimerspec current;
+        
+        while ((count = stream->GetData(0,1024,buffer,true)) > 0) {
+            for (index = 0; index < count; index++) {
+                fprintf(ofp_,"%10.5g\n",buffer[index]);
+            }
+            if (timer_gettime(timerid_,&current) == -1) {
+                perror("timer_gettime");
+                exit(EXIT_FAILURE);
+            }
+            if (current.it_value.tv_sec == 0 &&
+                current.it_value.tv_nsec == 0) {
+                stream->Stop();
+            }
+        }
+    }
+    FILE *ofp_;
+    timer_t timerid_;
+};
+
+int main(int argc, char *argv[])
+{
+    int seconds = 0;             // Seconds to collect for
+    const char *filename;        // Name of file to store values
+    
+    FILE *ofp;                   // File output stream
+    
+    ADC_Stream adc_stream;
+    TimedStream timedStream;
+    
+    // Check for CLI args
+    if (argc < 3) {
+        fprintf(stderr,"usage: %s seconds filename\n",argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    seconds = atoi(argv[1]);     // Get the seconds
+    filename = argv[2];          // Get the filename
+    
+    // Initialize A/D converter
+    adc_config();
+    
+    // Set the sample rate to 15kSPS
+    adc_set_samplerate(SAMP_RATE_15625); 
+    
+    // Set to channel 0
+    adc_set_chan0();
+    
+    if (strcmp(filename,"-") == 0) {
+        ofp = stdout;                 // "-" means stdout (terminal)
+    } else {
+        ofp = fopen(filename,"w");
+        if (ofp == NULL) {
+            perror("fopen");
+            exit(EXIT_FAILURE);
+        }
+    }
+            
+    timedStream.start(&adc_stream,seconds,ofp);
+
+    if (strcmp(filename,"-") != 0) fclose(ofp);
+    
+    exit(EXIT_SUCCESS);
+}
+

--- a/mainstream1.cc
+++ b/mainstream1.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Fri Sep 11 13:08:51 2020
-//  Last Modified : <200911.1429>
+//  Last Modified : <200914.1224>
 //
 //  Description	
 //
@@ -116,6 +116,9 @@ private:
     timer_t timerid_;
 };
 
+static ADC_Stream adc_stream;
+static TimedStream timedStream;
+
 int main(int argc, char *argv[])
 {
     int seconds = 0;             // Seconds to collect for
@@ -123,8 +126,6 @@ int main(int argc, char *argv[])
     
     FILE *ofp;                   // File output stream
     
-    ADC_Stream adc_stream;
-    TimedStream timedStream;
     
     // Check for CLI args
     if (argc < 3) {

--- a/pru0.c
+++ b/pru0.c
@@ -169,7 +169,7 @@ int main(void) {
       // Set up rx buffer
       rx_word_cnt = pMEM[memptr++];   // Number of bytes in one conversion value
       ncnv = pMEM[memptr++];          // Total number of conversions requested
-      rxmemptr = memptr;
+      rxmemptr = pMEM[memptr++];
       //for (i=0; i<ncnv; i++) { // Load rx buffer with zeros.  Can remove this.
       //  rx_words[i] = 0xff;  // pMEM[memptr++];
       //}

--- a/spidriver_host.c
+++ b/spidriver_host.c
@@ -294,7 +294,7 @@ uint32_t spi_write_cmd(uint32_t *data, int word_cnt) {
   uint32_t mem_ptr = 0x00;
   uint32_t N;
 
-  // printf("--> In spi_write_cmd, writing %d words\n", word_cnt);
+  //printf("--> In spi_write_cmd, writing %d words\n", word_cnt);
 
   // First set up PRU0 memory with data I want to transmit
   pru_write_word(mem_ptr++, 0xff);
@@ -451,7 +451,7 @@ uint8_t spi_writeread_continuous(uint32_t *txdata, int txcnt, uint32_t *rxdata, 
   N = 10000000;
   for (i=0; i<N; i++) {
     tmp = pru_read_word(0x00);
-    // printf("In spi_writeread_continuous, tmp = 0x%08x\n", tmp);
+    //if ((i%1000) == 0) printf("In spi_writeread_continuous, tmp = 0x%08x\n", tmp);
     if (!(tmp)) {
       break;
     }
@@ -504,7 +504,7 @@ uint32_t  spi_writeread_continuous_start(uint32_t *txdata, int txcnt, uint32_t r
   uint32_t rxptr;
   uint32_t N;
 
-  // printf("--> In spi_writeread_continuous, writing %d bytes\n", txcnt);
+  // printf("--> In spi_writeread_continuous_start, writing %d bytes\n", txcnt);
 
   // Set up transmitted data
   pru_write_word(memptr++, 0xff);      // Put PRU in "Wait for command" mode
@@ -519,7 +519,7 @@ uint32_t  spi_writeread_continuous_start(uint32_t *txdata, int txcnt, uint32_t r
   pru_write_word(memptr++, ncnv);   // Total number of conversions requested
   rxptr = memptr+1+rxoffset;                 // This points to begin of rx data.
   pru_write_word(memptr++,rxptr);   // Send receive buffer pointer RPH
-  pru_clear_block(rxptr,ncnv);   // Fast clear block
+  //pru_clear_block(rxptr,ncnv);   // Fast clear block
   //for (i = 0; i < ncnv; i++) {
   //  pru_write_word(memptr++, 0x00);
   //}
@@ -558,19 +558,21 @@ uint32_t spi_writeread_continuous_waitstart(uint32_t *txdata, int txcnt, uint32_
   N = 10000000;
   for (i=0; i<N; i++) {
     tmp = pru_read_word(0x00);
-    // printf("In spi_writeread_continuous, tmp = 0x%08x\n", tmp);
+    //if ((i%1000) == 0) printf("In spi_writeread_continuous_waitstart, tmp = 0x%08x\n", tmp);
     if (!(tmp)) {
       break;
     }
   }
   if (i == N) {
-    printf("In spi_writeread_continuous, timed out waiting for end of transaction!\n");
+    printf("In spi_writeread_continuous_waitstart, timed out waiting for end of transaction!\n");
     pru_reset(PRU0);
     prussdrv_exit();
     exit(-1); 
   } 
+    
+  // printf("After waiting for SPI_WRITEREAD_CONTINUOUS, i = %d, tmp = 0x%02x\n", i, tmp);
  
-  // printf("--> In spi_writeread_continuous, writing %d bytes\n", txcnt);
+  // printf("--> In spi_writeread_continuous_waitstart, writing %d bytes\n", txcnt);
 
   // Set up transmitted data
   pru_write_word(memptr++, 0xff);      // Put PRU in "Wait for command" mode
@@ -585,7 +587,7 @@ uint32_t spi_writeread_continuous_waitstart(uint32_t *txdata, int txcnt, uint32_
   pru_write_word(memptr++, ncnv);   // Total number of conversions requested
   rxptr = memptr+1+rxoffset;                 // This points to begin of rx data.
   pru_write_word(memptr++,rxptr);   // Send receive buffer pointer RPH
-  pru_clear_block(rxptr,ncnv);   // Fast clear block
+  //pru_clear_block(rxptr,ncnv);   // Fast clear block
   //for (i = 0; i < ncnv; i++) {
   //  pru_write_word(memptr++, 0x00);
   //}
@@ -611,13 +613,13 @@ void spi_writeread_continuous_wait() {
   N = 10000000;
   for (i=0; i<N; i++) {
     tmp = pru_read_word(0x00);
-    // printf("In spi_writeread_continuous, tmp = 0x%08x\n", tmp);
+    //if ((i%1000) == 0) printf("In spi_writeread_continuous_wait, (%d) tmp = 0x%08x\n", i, tmp);
     if (!(tmp)) {
       break;
     }
   }
   if (i == N) {
-    printf("In spi_writeread_continuous, timed out waiting for end of transaction!\n");
+    printf("In spi_writeread_continuous_wait, timed out waiting for end of transaction!\n");
     pru_reset(PRU0);
     prussdrv_exit();
     exit(-1); 


### PR DESCRIPTION
This is both Milestones 1 and 2 -- I built Milestone 2 as a test of the basic code.  

The program mainstream1.cc takes samples for the number of seconds on the command line to the file on the command line:

sudo ./mainstream1 seconds filename

if filename is a dash (-), then the output is to stdout.

each line of the output file is printed with the format %10.5g.

I modified pru0.c and spidriver_host.c to pass a rx buffer offset and modified spidriver_host.c to split apart the original spi_writeread_continuous into separate sections -- a start function, a wait function, and a transfer function.  I also changed the transfer code to use memcpy() instead of a for loop with pru_read_word() calls -- this should speed up the transfer from pru dataram to ARM memory. This allows implementing two buffers in PRU dataram.  I am overlaping copying from PRU dataram to ARM memory with fatching another buffer's worth from the ADC -- the PRU is SPI'ing to one buffer while the ARM is copying the other buffer to the ring buffer.