### PR TITLE
Remove unneeded WRITE_ADCMODE_REG, increase SPIBUFFERSIZE to 1020.

### DIFF
--- a/ADC_Stream.cc
+++ b/ADC_Stream.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 15:17:04 2020
-//  Last Modified : <200914.1235>
+//  Last Modified : <200915.1159>
 //
 //  Description	
 //
@@ -197,13 +197,6 @@ void * ADC_Stream::thread_()
         // Wait for the previous buffer to fill, then start filling
         // the other buffer.
         spi_writeread_continuous_wait();
-        
-        // Write mode register
-        //printf("WRITE_ADCMODE_REG\n");
-        tx_buf[0] = WRITE_ADCMODE_REG;
-        tx_buf[1] = 0x00;
-        tx_buf[2] = 0x0c;
-        spi_write_cmd(tx_buf, 3);
         
         // Read samples from data register to buffer
         tx_buf[0] = READ_DATA_REG;

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 14:26:26 2020
-//  Last Modified : <200914.1222>
+//  Last Modified : <200915.1214>
 //
 //  Description	
 //
@@ -49,7 +49,7 @@
 /** Buffer sizes.  These are the sizes of the buffers
  */
 
-#define SPIBUFFERSIZE 512 // Low-level SPI buffer
+#define SPIBUFFERSIZE 1020 // Low-level SPI buffer
 #define RINGBUFFERSIZE (8*SPIBUFFERSIZE) // High-level ring buffer
 
 


### PR DESCRIPTION
This greatly improves things.  Still a *few* spikes, but all below the data level.  I don't know if these are significant or not.