### PR TITLE
Handle buffer overrun cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@
 # ARM code
 CC := gcc
 CXX := g++
-CFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
-CXXFLAGS := -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
+CFLAGS := -g -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
+CXXFLAGS := -g -O3 -mfpu=vfpv3 -mfloat-abi=hard -march=armv7 -I./include
 # LDFLAGS := -lprussdrv
 LDFLAGS := -lrt -lpthread
 
@@ -19,7 +19,7 @@ OBJS1 = mainstream1.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
 #OBJS2 = mainstream2.o prussdrv.o adcdriver_host.o spidriver_host.o ADC_Stream.o
 EXES := main mainstream1 # mainstream2
 INCLUDEDIR := ./include
-INCLUDES := $(addprefix $(INCLUDEDIR)/, prussdrv.h pru_types.h __prussdrv.h pruss_intc_mapping.h spidriver_host.h adcdriver_host.h)
+INCLUDES := $(addprefix $(INCLUDEDIR)/, prussdrv.h pru_types.h __prussdrv.h pruss_intc_mapping.h spidriver_host.h adcdriver_host.h ADC_Stream.h)
 
 #----------------------------------------------------
 # PRU code
@@ -77,7 +77,8 @@ prussdrv.o: prussdrv.c # $(DEPS)
 	$(CC) $(CFLAGS) -E -MM  -c $< -MF $<.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
-ADC_Stream.o: ADC_Stream.cc # $(DEPS)
+ADC_Stream.o: ADC_Stream.cc ./include/ADC_Stream.h \
+		./include/adcdriver_host.h ./include/spidriver_host.h 
 	echo "--> Building ADC_Stream.o"
 	$(CXX) $(CXXFLAGS) -E -MM  -c $< -MF $<.d
 	$(CXX) $(CXXFLAGS) -c $< -o $@

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 14:26:26 2020
-//  Last Modified : <200915.1214>
+//  Last Modified : <200919.2137>
 //
 //  Description	
 //
@@ -46,10 +46,21 @@
 #include <stdint.h>
 #include <pthread.h>
 
-/** Buffer sizes.  These are the sizes of the buffers
+/** Buffer sizes.  These are the sizes of the buffers, in units of
+ * uint32_t (32-bit unsigned -- 4 bytes each).
  */
 
-#define SPIBUFFERSIZE 1020 // Low-level SPI buffer
+// SPIBUFFERSIZE can be no more than (((8192-128)-(6*sizeof(uint32_t))/sizeof(uint32_t))/2,
+// which is 1005.  This is because the PRU Dataram is 8192 bytes and
+// both buffers, plus the 6 command words need to fit in that memory.
+// (For some reason, the first 128 bytes of PRU Dataram is not 
+// available.)
+#define SPIBUFFERSIZE 875 // Low-level SPI buffer size
+// RINGBUFFERSIZE *MUST* be an exact integer multiple of 
+// SPIBUFFERSIZE, to avoid split buffer wraparound fun.  The larger 
+// the better, but remember the Beagles only have 512Meg of physical 
+// memory, and swapping should probably be avoided, since will slow
+// down the main thread, which might make it harder to keep up.
 #define RINGBUFFERSIZE (8*SPIBUFFERSIZE) // High-level ring buffer
 
 
@@ -163,8 +174,6 @@ private:
     bool end_;
     /** Thread object. */
     pthread_t threadHandle_;
-    /** New data flag */
-    bool newdata_;
 };
     
 

--- a/mainstream1.cc
+++ b/mainstream1.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Fri Sep 11 13:08:51 2020
-//  Last Modified : <200914.1224>
+//  Last Modified : <200919.2146>
 //
 //  Description	
 //
@@ -94,11 +94,11 @@ private:
     }
     void callback_(ADC_Stream *stream,uint32_t available)
     {
-        float buffer[1024];
+        static float buffer[2048];
         uint32_t count, index;
         struct itimerspec current;
         
-        while ((count = stream->GetData(0,1024,buffer,true)) > 0) {
+        while ((count = stream->GetData(0,2048,buffer,true)) > 0) {
             for (index = 0; index < count; index++) {
                 fprintf(ofp_,"%10.5g\n",buffer[index]);
             }
@@ -106,6 +106,7 @@ private:
                 perror("timer_gettime");
                 exit(EXIT_FAILURE);
             }
+            //fprintf(stderr,"*** TimedStream::callback_(): current time is %u / %u\n",current.it_value.tv_sec,current.it_value.tv_nsec);
             if (current.it_value.tv_sec == 0 &&
                 current.it_value.tv_nsec == 0) {
                 stream->Stop();


### PR DESCRIPTION
I think I pretty much have it.  Buffer overruns are detected and handled.  There are still some spikes, so it looks like there might still be some dropped data points.  I am not sure how we can handle this.  My only thought might be to either use pru1 to do the actual copying to ARM memory (which might be possible, since the pru can access ARM memory).  Maybe using the 12K *shared* memory which would allow larger buffers.  Another option would be a kernel driver, which would be able to access pru memory and ARM memory without the overhead of mmap.

There are sometimes PRU SPI timeouts.  I don't know what causes that.