### PR TITLE
Update thread scheduling and priority parameters to reduce dropped samples.

### DIFF
--- a/ADC_Stream.cc
+++ b/ADC_Stream.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 15:17:04 2020
-//  Last Modified : <200919.2141>
+//  Last Modified : <201031.1308>
 //
 //  Description	
 //
@@ -78,6 +78,8 @@ static const char rcsid[] = "@(#) : $Id$";
  */
 void ADC_Stream::Start(Callback_t callback, void *usercontext)
 {
+    struct sched_param param = {.sched_priority = 71 };
+    pthread_attr_t attr;
     // Initialize instance variables:
     callback_ = callback;          // Save Callback function
     usercontext_ = usercontext;    // Save User Context
@@ -86,7 +88,12 @@ void ADC_Stream::Start(Callback_t callback, void *usercontext)
     inpointer_ = 0;                // Reset Ring Buffer pointer indexes
     outpointer_ = 0;
     // Create thread to read data
-    int result = pthread_create(&threadHandle_,NULL,
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+    pthread_attr_setschedparam(&attr, &param);
+    int result = pthread_create(&threadHandle_,&attr,
                                 ADC_Stream::thread__,
                                 (void *)this);
     // Error check

--- a/include/ADC_Stream.h
+++ b/include/ADC_Stream.h
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Sat Sep 5 14:26:26 2020
-//  Last Modified : <201021.1300>
+//  Last Modified : <201031.1314>
 //
 //  Description	
 //
@@ -55,7 +55,7 @@
 // both buffers, plus the 6 command words need to fit in that memory.
 // (For some reason, the first 128 bytes of PRU Dataram is not 
 // available.)
-#define SPIBUFFERSIZE 900 // Low-level SPI buffer size
+#define SPIBUFFERSIZE 850 // Low-level SPI buffer size
 // RINGBUFFERSIZE *MUST* be an exact integer multiple of 
 // SPIBUFFERSIZE, to avoid split buffer wraparound fun.  The larger 
 // the better, but remember the Beagles only have 512Meg of physical 

--- a/mainstream1.cc
+++ b/mainstream1.cc
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Fri Sep 11 13:08:51 2020
-//  Last Modified : <200919.2146>
+//  Last Modified : <201031.1311>
 //
 //  Description	
 //
@@ -110,6 +110,7 @@ private:
             if (current.it_value.tv_sec == 0 &&
                 current.it_value.tv_nsec == 0) {
                 stream->Stop();
+                break;
             }
         }
     }


### PR DESCRIPTION
This is an update that changes the thread scheduling and priority parameters, which seems to improve things to reduce dropped samples.